### PR TITLE
Fix for Warning: 1265 Data truncated for column 'lat' at row 1 error

### DIFF
--- a/MapMarker.php
+++ b/MapMarker.php
@@ -30,8 +30,8 @@ class MapMarker extends WireData {
 	protected $geocodedAddress = '';
 
 	public function __construct() {
-		$this->set('lat', '');
-		$this->set('lng', '');
+		$this->set('lat', 0);
+		$this->set('lng', 0);
 		$this->set('address', ''); 
 		$this->set('status', 0); 
 		$this->set('zoom', 0); 


### PR DESCRIPTION
See:
http://processwire.com/talk/topic/5833-problem-creating-new-page-from-api-with-custom-field-with-a-float-subfield/

Although you can ignore most of that, because you'll notice at the end I realize that it's admin as well, and not just API generated pages. 

Thanks for Wanze for noticing the easy fix!
