### PR TITLE
Periodically check for AJAX-loaded Inputfields and init() them

### DIFF
--- a/InputfieldMapMarker.js
+++ b/InputfieldMapMarker.js
@@ -123,8 +123,13 @@ var InputfieldMapMarker = {
 };
 
 $(document).ready(function() {
-	$(".InputfieldMapMarkerMap").each(function() {
-		var $t = $(this);
-		InputfieldMapMarker.init($t.attr('id'), $t.attr('data-lat'), $t.attr('data-lng'), $t.attr('data-zoom'), $t.attr('data-type')); 
-	}); 
+	// Inputfields that are loaded by AJAX (e.g. in a collapsed repeater) might not exist yet on document.ready
+	// Periodically check for new InputfieldMapMarkerMaps and init them
+	window.setInterval( function initMapMarkersDelayed() {
+		$(".InputfieldMapMarkerMap.uninitialized").each(function() {
+			var $t = $(this);
+			$t.removeClass('uninitialized');
+			InputfieldMapMarker.init($t.attr('id'), $t.attr('data-lat'), $t.attr('data-lng'), $t.attr('data-zoom'), $t.attr('data-type')); 
+		});
+	}, 1000);
 }); 

--- a/InputfieldMapMarker.module
+++ b/InputfieldMapMarker.module
@@ -156,7 +156,7 @@ class InputfieldMapMarker extends Inputfield {
 
 _OUT;
 
-		$out .= "<div class='InputfieldMapMarkerMap' " . 
+		$out .= "<div class='InputfieldMapMarkerMap uninitialized' " . 
 			"id='_{$id}_map' " . 
 			"style='height: {$height}px' " . 
 			"data-lat='$marker->lat' " . 


### PR DESCRIPTION
I had a problem with MapMarkers that are in a PageTable or a (collapsed) repeater.
Those MapMarkers don't exist yet upon document.ready so they wouldn't be initialized and didn't show a map. See my comment at https://processwire.com/talk/topic/9711-map-marker-map/?do=findComment&comment=129945

My suggestion is to look for new MapMarkers periodically and initialize them then.
This introduces a slight delay but is still faster than using non-collapsed repeaters.