### PR TITLE
Update Google Maps API to use current version, resolve error that prevents rendering maps

### DIFF
--- a/InputfieldMapMarker.js
+++ b/InputfieldMapMarker.js
@@ -5,126 +5,119 @@
 
 var InputfieldMapMarker = {
 
-	options: {
-		zoom: 12, // mats, previously 5
-		draggable: true, // +mats
-		center: null,
-		//key: config.InputfieldMapMarker.googleApiKey, 
-		mapTypeId: google.maps.MapTypeId.HYBRID,
-		scrollwheel: false,	
-		mapTypeControlOptions: {
-			style: google.maps.MapTypeControlStyle.DROPDOWN_MENU
-		},
-		scaleControl: false
-	},	
+  options: {
+    zoom: 12,
+    draggable: true, // +mats
+    center: null,
+    mapTypeId: google.maps.MapTypeId.HYBRID,
+    scrollwheel: false,
+    mapTypeControlOptions: {
+      style: google.maps.MapTypeControlStyle.DROPDOWN_MENU
+    },
+    scaleControl: false
+  },
 
-	init: function(mapId, lat, lng, zoom, mapType) {
+  init: function(mapId, lat, lng, zoom, mapType) {
 
-		var options = InputfieldMapMarker.options; 
+    var options = InputfieldMapMarker.options;
 
-		if(zoom < 1) zoom = 12; 
-		options.center = new google.maps.LatLng(lat, lng); 	
-		options.zoom = parseInt(zoom); 
+    if(zoom < 1) zoom = 12;
+    options.center = new google.maps.LatLng(lat, lng);
+    options.zoom = parseInt(zoom);
 
-		if(mapType == 'SATELLITE') options.mapTypeId = google.maps.MapTypeId.SATELLITE; 
-			else if(mapType == 'ROADMAP') options.mapTypeId = google.maps.MapTypeId.ROADMAP; 
+    if(mapType == 'SATELLITE') options.mapTypeId = google.maps.MapTypeId.SATELLITE;
+    else if(mapType == 'ROADMAP') options.mapTypeId = google.maps.MapTypeId.ROADMAP;
 
-		var map = new google.maps.Map(document.getElementById(mapId), options); 	
+    function initMapActions(map, marker, geocoder) {
+      var $map = $('#' + mapId);
+      var $lat = $map.siblings(".InputfieldMapMarkerLat").find("input[type=text]");
+      var $lng = $map.siblings(".InputfieldMapMarkerLng").find("input[type=text]");
+      var $addr = $map.siblings(".InputfieldMapMarkerAddress").find("input[type=text]");
+      var $addrJS = $map.siblings(".InputfieldMapMarkerAddress").find("input[type=hidden]");
+      var $toggle = $map.siblings(".InputfieldMapMarkerToggle").find("input[type=checkbox]");
+      var $zoom = $map.siblings(".InputfieldMapMarkerZoom").find("input[type=number]");
+      var $notes = $map.siblings(".notes");
 
-		var marker = new google.maps.Marker({
-			position: options.center, 
-			map: map,
-			draggable: options.draggable	
-		}); 
+      $lat.val(marker.position.lat);
+      $lng.val(marker.position.lng);
+      $zoom.val(map.getZoom());
 
-		var $map = $('#' + mapId); 
-		var $lat = $map.siblings(".InputfieldMapMarkerLat").find("input[type=text]");
-		var $lng = $map.siblings(".InputfieldMapMarkerLng").find("input[type=text]");
-		var $addr = $map.siblings(".InputfieldMapMarkerAddress").find("input[type=text]"); 
-		var $addrJS = $map.siblings(".InputfieldMapMarkerAddress").find("input[type=hidden]"); 
-		var $toggle = $map.siblings(".InputfieldMapMarkerToggle").find("input[type=checkbox]");
-		var $zoom = $map.siblings(".InputfieldMapMarkerZoom").find("input[type=number]");
-		var $notes = $map.siblings(".notes");
+      $addr.blur(function() {
+        var address = $(this).val();
 
-		$lat.val(marker.getPosition().lat());
-		$lng.val(marker.getPosition().lng());
-		$zoom.val(map.getZoom()); 
+        if(!$toggle.is(":checked") || !address) return true;
 
-		google.maps.event.addListener(marker, 'dragend', function(event) {
-			var geocoder = new google.maps.Geocoder();
-			var position = this.getPosition();
-			$lat.val(position.lat());
-			$lng.val(position.lng());
-			if($toggle.is(":checked")) {
-				geocoder.geocode({ 'latLng': position }, function(results, status) {
-					if(status == google.maps.GeocoderStatus.OK && results[0]) {
-						$addr.val(results[0].formatted_address);	
-						$addrJS.val($addr.val()); 
-					}
-					$notes.text(status);
-				});
-			}
-		});
+        geocoder.geocode({ 'address': address }, function(results, status) {
+          if(status == google.maps.GeocoderStatus.OK && results[0]) {
+            var position = results[0].geometry.location;
+            map.setCenter(position);
+            marker.position = position;
+            $lat.val(position.lat());
+            $lng.val(position.lng());
+            $addrJS.val($addr.val());
+          }
+          $notes.text(status);
+        });
+        return true;
+      });
 
-		google.maps.event.addListener(map, 'zoom_changed', function() {
-			$zoom.val(map.getZoom()); 
-		}); 
+      $zoom.change(function() {
+        map.setZoom(parseInt($(this).val()));
+      });
 
-		$addr.blur(function() {
-			if(!$toggle.is(":checked")) return true;
-			var geocoder = new google.maps.Geocoder();
-			geocoder.geocode({ 'address': $(this).val()}, function(results, status) {
-				if(status == google.maps.GeocoderStatus.OK && results[0]) {
-					var position = results[0].geometry.location;
-					map.setCenter(position);
-					marker.setPosition(position);
-					$lat.val(position.lat());
-					$lng.val(position.lng());
-					$addrJS.val($addr.val()); 
-				}
-				$notes.text(status); 
-			});
-			return true;	
-		}); 
+      $toggle.click(function() {
+        if($(this).is(":checked")) {
+          $notes.text('Geocode ON');
+        // google.maps.event.trigger(marker, 'dragend');
+          $addr.trigger('blur');
+        } else {
+          $notes.text('Geocode OFF');
+        }
+        return true;
+      });
 
-		$zoom.change(function() {
-			map.setZoom(parseInt($(this).val())); 
-		}); 
+    // added by diogo to solve the problem of maps not rendering correctly in hidden elements
+    // trigger a resize on the map when either the tab button or the toggle field bar are pressed
 
-		$toggle.click(function() {
-			if($(this).is(":checked")) {
-				$notes.text('Geocode ON');
-				// google.maps.event.trigger(marker, 'dragend'); 
-				$addr.trigger('blur');
-			} else {
-				$notes.text('Geocode OFF');
-			}
-			return true;
-		});
+    // get the tab element where this map is integrated
+      var $map = $('#' + mapId);
+      var $tab = $('#_' + $map.closest('.InputfieldFieldsetTabOpen').attr('id'));
+    // get the inputfield where this map is integrated and add the tab to the stack
+      var $inputFields = $map.closest('.Inputfield').find('.InputfieldStateToggle').add($tab);
 
-		// added by diogo to solve the problem of maps not rendering correctly in hidden elements
-		// trigger a resize on the map when either the tab button or the toggle field bar are pressed
+      $inputFields.on('click',function(){
+      // give it time to open
+        window.setTimeout(function(){
+          google.maps.event.trigger(map,'resize');
+          map.setCenter(options.center);
+        }, 200);
+      });
+    }
 
-		// get the tab element where this map is integrated
-		var $map = $('#' + mapId); 
-		var $tab = $('#_' + $map.closest('.InputfieldFieldsetTabOpen').attr('id'));
-		// get the inputfield where this map is integrated and add the tab to the stack
-		var $inputFields = $map.closest('.Inputfield').find('.InputfieldStateToggle').add($tab);
+    /**
+     * Initialize all Google Maps API objects
+     */
+    async function initMap() {
+      var { Map } = await google.maps.importLibrary("maps");
+      var { AdvancedMarkerElement } = await google.maps.importLibrary("marker");
+      var { Geocoder } = await google.maps.importLibrary("geocoding");
 
-		$inputFields.on('click',function(){
-			// give it time to open
-			window.setTimeout(function(){
-				google.maps.event.trigger(map,'resize');
-				map.setCenter(options.center); 
-			}, 200);
-		});
-		
-	}
+      options.mapId = mapId;
+
+      var map = new Map(document.getElementById(mapId), options);
+      var marker = new AdvancedMarkerElement({ map, position: options.center });
+      var geocoder = new Geocoder();
+
+      initMapActions(map, marker, geocoder);
+    }
+
+    initMap();
+  }
 };
 
 $(document).ready(function() {
-	$(".InputfieldMapMarkerMap").each(function() {
-		var $t = $(this);
-		InputfieldMapMarker.init($t.attr('id'), $t.attr('data-lat'), $t.attr('data-lng'), $t.attr('data-zoom'), $t.attr('data-type')); 
-	}); 
+  $(".InputfieldMapMarkerMap").each(function() {
+    var $t = $(this);
+    InputfieldMapMarker.init($t.attr('id'), $t.attr('data-lat'), $t.attr('data-lng'), $t.attr('data-zoom'), $t.attr('data-type'));
+  });
 }); 


### PR DESCRIPTION
Replaced previous Google APIs with current versions. Uses new async method that prevents warnings in inspector console.

Updated maps API to use new method in the [Google Maps documentation](https://developers.google.com/maps/documentation/javascript/adding-a-google-map)

Updated marker API according to [this guide by Google](https://developers.google.com/maps/documentation/javascript/advanced-markers/migration)

All features appear to be working.